### PR TITLE
fix for current bugs while changing maps

### DIFF
--- a/cabin.json
+++ b/cabin.json
@@ -29,9 +29,9 @@
          "opacity":1,
          "properties":[
                 {
-                 "name":"exitSceneUrl",
+                 "name":"exitUrl",
                  "type":"string",
-                 "value":"https:\/\/n0rc.github.io\/workadventure-maps\/snow.json#entryCabin"
+                 "value":"..\/..\/n0rc.github.io\/workadventure-maps\/snow.json#entryCabin"
                 }],
          "type":"tilelayer",
          "visible":true,


### PR DESCRIPTION
The workadventure docs regarding map creation are still not clear, currently map transitions seem to be a bit broken.

Using `exitUrl` and relative paths seem to work for now.